### PR TITLE
chore: cleanup dependency graph

### DIFF
--- a/.changeset/small-apples-confess.md
+++ b/.changeset/small-apples-confess.md
@@ -1,0 +1,5 @@
+---
+"clerk-solidjs": patch
+---
+
+Cleanup dependency graph

--- a/packages/clerk-solidjs/package.json
+++ b/packages/clerk-solidjs/package.json
@@ -132,21 +132,19 @@
   },
   "dependencies": {
     "@clerk/backend": "^1.3.1",
-    "@clerk/clerk-js": "^5.8.1",
     "@clerk/shared": "^2.3.1",
     "@solid-primitives/context": "^0.2.3",
     "@solid-primitives/destructure": "^0.1.17",
     "@solid-primitives/memo": "^1.3.9",
-    "@solid-primitives/static-store": "^0.0.8",
-    "@solidjs/testing-library": "^0.8.8",
-    "@tanstack/solid-query": "^5.51.2",
-    "prettier-plugin-organize-imports": "^4.0.0"
+    "@tanstack/solid-query": "^5.51.2"
   },
   "devDependencies": {
+    "@clerk/clerk-js": "^5.8.1",
     "@clerk/localizations": "^2.4.6",
     "@clerk/themes": "^2.1.10",
     "@clerk/types": "^4.6.1",
     "@eslint/js": "^9.6.0",
+    "@solidjs/testing-library": "^0.8.8",
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/user-event": "^14.5.2",
     "@types/node": "^20.14.10",
@@ -155,6 +153,7 @@
     "globals": "^15.8.0",
     "jsdom": "^24.1.0",
     "prettier": "3.3.3",
+    "prettier-plugin-organize-imports": "^4.0.0",
     "rimraf": "^6.0.1",
     "tsup": "^8.1.0",
     "tsup-preset-solid": "^2.2.0",

--- a/packages/clerk-solidjs/src/hooks/use-email-link.ts
+++ b/packages/clerk-solidjs/src/hooks/use-email-link.ts
@@ -4,7 +4,7 @@ import type {
   SignUpResource
 } from '@clerk/types';
 import { destructure } from '@solid-primitives/destructure';
-import { Accessor, createEffect, createMemo } from 'solid-js';
+import { Accessor, createEffect, createMemo, onCleanup } from 'solid-js';
 
 type EmailLinkable = SignUpResource | EmailAddressResource | SignInResource;
 
@@ -12,7 +12,7 @@ function useEmailLink(resource: Accessor<EmailLinkable>) {
   const linkFlows = createMemo(() => resource().createEmailLinkFlow());
 
   createEffect(() => {
-    return linkFlows().cancelEmailLinkFlow;
+    onCleanup(linkFlows().cancelEmailLinkFlow);
   });
 
   return destructure(linkFlows);

--- a/packages/clerk-solidjs/src/utils/use-max-allowed-instances-guard.tsx
+++ b/packages/clerk-solidjs/src/utils/use-max-allowed-instances-guard.tsx
@@ -1,4 +1,4 @@
-import { Accessor, Component, createEffect } from 'solid-js';
+import { Accessor, Component, createEffect, onCleanup } from 'solid-js';
 import { errorThrower } from '../errors/error-thrower';
 
 const counts = new Map<string, number>();
@@ -13,9 +13,9 @@ export function useMaxAllowedInstancesGuard(
     }
     counts.set(props().name, count + 1);
 
-    return () => {
+    onCleanup(() => {
       counts.set(props().name, (counts.get(props().name) || 1) - 1);
-    };
+    });
   });
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,6 @@ importers:
       '@clerk/backend':
         specifier: ^1.3.1
         version: 1.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@clerk/clerk-js':
-        specifier: ^5.8.1
-        version: 5.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/shared':
         specifier: ^2.3.1
         version: 2.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -66,25 +63,19 @@ importers:
       '@solid-primitives/memo':
         specifier: ^1.3.9
         version: 1.3.9(solid-js@1.8.18)
-      '@solid-primitives/static-store':
-        specifier: ^0.0.8
-        version: 0.0.8(solid-js@1.8.18)
       '@solidjs/start':
         specifier: ^1
         version: 1.0.4(@testing-library/jest-dom@6.4.6(vitest@2.0.3(@types/node@20.14.10)(jsdom@24.1.0)(terser@5.31.2)))(rollup@4.18.1)(solid-js@1.8.18)(vinxi@0.3.14(@types/node@20.14.10)(ioredis@5.4.1)(terser@5.31.2))(vite@5.3.3(@types/node@20.14.10)(terser@5.31.2))
-      '@solidjs/testing-library':
-        specifier: ^0.8.8
-        version: 0.8.8(@solidjs/router@0.14.1(solid-js@1.8.18))(solid-js@1.8.18)
       '@tanstack/solid-query':
         specifier: ^5.51.2
         version: 5.51.2(solid-js@1.8.18)
-      prettier-plugin-organize-imports:
-        specifier: ^4.0.0
-        version: 4.0.0(prettier@3.3.3)(typescript@5.5.3)
       solid-js:
         specifier: ^1.8
         version: 1.8.18
     devDependencies:
+      '@clerk/clerk-js':
+        specifier: ^5.8.1
+        version: 5.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/localizations':
         specifier: ^2.4.6
         version: 2.4.6
@@ -97,6 +88,9 @@ importers:
       '@eslint/js':
         specifier: ^9.6.0
         version: 9.7.0
+      '@solidjs/testing-library':
+        specifier: ^0.8.8
+        version: 0.8.8(@solidjs/router@0.14.1(solid-js@1.8.18))(solid-js@1.8.18)
       '@testing-library/jest-dom':
         specifier: ^6.4.6
         version: 6.4.6(vitest@2.0.3(@types/node@20.14.10)(jsdom@24.1.0)(terser@5.31.2))
@@ -121,6 +115,9 @@ importers:
       prettier:
         specifier: 3.3.3
         version: 3.3.3
+      prettier-plugin-organize-imports:
+        specifier: ^4.0.0
+        version: 4.0.0(prettier@3.3.3)(typescript@5.5.3)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1


### PR DESCRIPTION
Needed to change some dependencies to devDependencies, remove unused.

Also fixed a couple `createEffect` `onCleanup` functions